### PR TITLE
feat: Add parameter to override redirectUrl

### DIFF
--- a/example/routes/index.js
+++ b/example/routes/index.js
@@ -68,6 +68,11 @@ router.get('/callback', function(req, res, next) {
   res.sendFile(path.join(__dirname + '/../views/html/index.html'));
 });
 
+// callback function (different url) - directs back to home page
+router.get('/custom/callback', function(req, res, next) {
+  res.sendFile(path.join(__dirname + '/../views/html/index.html'));
+});
+
 // function for getting environment variables to the frontend
 router.get('/getAuthoriseUrl', function(req, res, next) {
   var purpose = 'demonstrating MyInfo APIs'

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,18 +16,18 @@ class MyInfoClient {
     this._redirectUrl = options.redirectUrl;
   }
 
-  getAuthoriseUrl(purpose, attributes) {
+  getAuthoriseUrl(purpose, attributes, redirectUrl) {
     const state = crypto.randomBytes(16).toString('hex');
     const authoriseUrl = `${this._authApiUrl}\
 ?client_id=${this._clientId}\
 &attributes=${attributes.join(',')}\
 &purpose=${purpose}\
 &state=${state}\
-&redirect_uri=${this._redirectUrl}`;
+&redirect_uri=${redirectUrl || this._redirectUrl}`;
     return { authoriseUrl, state };
   }
 
-  async getToken(code) {
+  async getToken(code, redirectUrl) {
     const {
       _authLevel, _clientId, _clientSecret, _privateKeyPath, _redirectUrl, _tokenApiUrl,
     } = this;
@@ -36,7 +36,7 @@ class MyInfoClient {
 
     const params = {
       grant_type: 'authorization_code',
-      redirect_uri: _redirectUrl,
+      redirect_uri: redirectUrl || _redirectUrl,
       client_id: _clientId,
       client_secret: _clientSecret,
       code,


### PR DESCRIPTION
Add an extra `redirectUrl` parameter to the `getAuthoriseUrl` and `getToken` methods to allow using a different value from the one set when creating the `MyInfoClient` instance without having to instantiate the class again.

This can be useful if you retrieve data from MyInfo at multiple places in your app and want it to direct to different pages accordingly. Without this change it's still possible by either creating a new instance of `MyInfoClient` for each url, or it can be managed client side with a generic redirect page that will reroute to the relevant location.